### PR TITLE
Revert "neurondemo may be a python wrapper (i.e. wheel) (#11)"

### DIFF
--- a/runtests
+++ b/runtests
@@ -4,12 +4,7 @@ export NRNUNIT_USE_LEGACY=1
 
 CURRENT_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 sh "$CURRENT_DIR/testutil/clean"
-if [[ -x "$(which neurondemo)" ]]
-then
-    neurondemo -c 'quit()'
-else
-    sh neurondemo -c 'quit()'
-fi
+neurondemo -c 'quit()'
 
 have_nrnpython=yes
 have_nrnmpi=yes


### PR DESCRIPTION
This reverts commit b953a0961a149c7b96319afd49cc78d19d624dd9.

Fixed upstream in https://github.com/neuronsimulator/nrn/pull/1463