### PR TITLE
arm64 cvode.use_long_double(1) same as double

### DIFF
--- a/fast/t13.hoc
+++ b/fast/t13.hoc
@@ -52,4 +52,6 @@ strdef s
 //{system("cmp temp t13.stdout", s)}
 //b = b && (strcmp(s, "") == 0)
 {load_file("compare.hoc")}
-b = b && (compare_files("temp", "t13.stdout", 1e-8) || compare_files("temp", "t13.stdout.c3", 1e-8))
+if (strcmp(nrnversion(8), "arm64-Darwin") != 0) { // use_long_double(1) same as double
+  b = b && (compare_files("temp", "t13.stdout", 1e-8) || compare_files("temp", "t13.stdout.c3", 1e-8))
+}

--- a/fast/t14.hoc
+++ b/fast/t14.hoc
@@ -65,5 +65,7 @@ prun("temp.cvode.3")
 b = 1
 b = b && compare_files("temp.fixed", "temp.fixed.3", 1e-11)
 b = b && compare_files("temp.fixed", "t14.fixed.stdout", 1e-10)
-b = b && (compare_files("temp.cvode", "temp.cvode.3", 1e-11))
+if (strcmp(nrnversion(8), "arm64-Darwin") != 0) { // use_long_double(1) same as double
+  b = b && (compare_files("temp.cvode", "temp.cvode.3", 1e-11))
+}
 b = b && (compare_files("temp.cvode", "t14.cvode.stdout", 1e-6) || compare_files("temp.cvode", "t14.cvode.stdout.c3", 1e-6))


### PR DESCRIPTION
t13.hoc and t14.hoc avoid a cvode comparison for cvode.use_long_double(1) if the architecture is arm64 as that is the same as double