### PR TITLE
drop alltoall_dict.py test + allow oversubscribe to be overwritten 

### DIFF
--- a/nrniv/Parallel/dotests.sh
+++ b/nrniv/Parallel/dotests.sh
@@ -2,7 +2,7 @@
 
 err=0
 
-files=("alltoall.py" "alltoall_dict.py" "collective.py" "pargap/msgap.py")
+files=("alltoall.py" "collective.py" "pargap/msgap.py")
 nrnivmodl pargap
 
 function f() {

--- a/nrniv/Parallel/dotests.sh
+++ b/nrniv/Parallel/dotests.sh
@@ -7,7 +7,7 @@ nrnivmodl pargap
 
 function f() {
   echo "Running nrniv/Parallel/${1}"
-  a=$(mpiexec --oversubscribe -n 4 nrniv -nobanner -mpi -python $1 2>/dev/null | sed -n '$p')
+  a=$(mpiexec ${MPIEXEC_OVERSUBSCRIBE---oversubscribe} -n 4 nrniv -nobanner -mpi -python $1 2>/dev/null | sed -n '$p')
   echo "${1} stdout: ${a}"
   if test "$a" != 0 ; then
     echo "$1 failed"


### PR DESCRIPTION
allow oversubscribe to be overwritten
* needed for mpich testing via `nrn-build-ci`

drop alltoall_dict.py testing
* rely on basic test from NRN via neuronsimulator/nrn#1486
