### PR TITLE
Drop obsolete declarations.

### DIFF
--- a/nrniv/Parallel/recv/invlfire.mod
+++ b/nrniv/Parallel/recv/invlfire.mod
@@ -57,11 +57,6 @@ typedef struct RecvInfo {
 	IvocVect* srcvec;
 	IvocVect* tarvec;
 } RecvInfo;
-#ifndef __cplusplus
-typedef struct Rand Rand;
-Rand* nrn_random_arg(int);
-double nrn_random_pick(Rand*);
-#endif
 ENDVERBATIM
 
 NET_RECEIVE (w, srcgid) {


### PR DESCRIPTION
- These changes make `nrntest` compatible with translated MOD files being compiled as C++ (https://github.com/neuronsimulator/nrn/pull/1597).
- Now that https://github.com/neuronsimulator/nrn/pull/1755 is merged, `nrntest` should still be compatible with `master`.