### PR TITLE
Do not call cvode.cache_efficient

### DIFF
--- a/nmodl/area1.cmp
+++ b/nmodl/area1.cmp
@@ -1,3 +1,2 @@
-	0 
 Area from MOD: 157080 
 Area from HOC: 157079.63 

--- a/nmodl/area1.hoc
+++ b/nmodl/area1.hoc
@@ -2,7 +2,6 @@
 create a
 access a
 insert test
-cvode.cache_efficient(0)
 init()
 step()
 


### PR DESCRIPTION
In nrn#2027 this becomes a no-op and the static return value is 1.